### PR TITLE
自分の商品を削除し、削除後トップページへ遷移する記述

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create, :edit, :update]
-  before_action :move_to_index, except: [:index, :show, :new, :create]
-  before_action :set_item, only: [:show, :edit, :update]
+  before_action :move_to_index, except: [:index, :show, :new, :create, :destroy]
+  before_action :set_item, only: [:show, :edit, :update, :destroy]
   def index
     @items = Item.order("created_at DESC")
   end
@@ -23,6 +23,11 @@ class ItemsController < ApplicationController
   end
 
   def edit
+  end
+
+  def destroy
+    @item.destroy
+    redirect_to root_path
   end
 
   def update

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: [:new, :create, :edit, :update]
+  before_action :authenticate_user!, only: [:new, :create, :edit, :update, :destroy]
   before_action :move_to_index, except: [:index, :show, :new, :create, :destroy]
   before_action :set_item, only: [:show, :edit, :update, :destroy]
   def index

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -26,7 +26,7 @@
      <% if user_signed_in? && current_user.id == @item.user_id %>
     <%= link_to "商品の編集", edit_item_path, method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
-    <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+    <%= link_to "削除",item_path(@item), data: { turbo_method: :delete }, class:"item-destroy" %>
     <% end %>
 
     <%# 商品が売れていない場合はこちらを表示しましょう %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   devise_for :users
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
   root 'items#index'
-  resources :items, only: [:index, :new,:create,:show, :edit, :update]
+  resources :items, only: [:index, :new,:create,:show, :edit, :update, :destroy]
   # Defines the root path route ("/")
   # root "articles#index"
 end


### PR DESCRIPTION
[what]
商品削除機能の実装
[why]
商品出品者が商品を削除できるよう実装

- [ ] ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画
https://gyazo.com/81449cad7f04311616720f8b8ec0ddf7